### PR TITLE
Add simple demo webapp and wallet CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ Este proyecto se encuentra en una **fase conceptual y de investigación**. El tr
 * **Plataforma L2 Inicial:** Se ha seleccionado **Arbitrum** como la plataforma L2 inicial para el despliegue del MSC Ledger, debido a su alta escalabilidad, bajos costes de transacción y compatibilidad con EVM.
 
 El prototipado de la *lógica central* de MSC (simulación de agentes y grafos) se realiza en un repositorio separado: [**esraderey/synth-msc**](https://github.com/esraderey/synth-msc). Este repositorio (`msc-network-protocol`) está enfocado en la visión y el diseño de la **infraestructura descentralizada**.
+### Demo Webapp
+
+Se incluye un ejemplo basico de aplicacion web en `webapp/` que permite visualizar y anadir bloques a una cadena en memoria.
+Para ejecutarla, instala las dependencias y ejecuta:
+
+```bash
+python webapp/app.py
+```
+
+Luego abre `http://localhost:5000` en tu navegador.
+Para generar una nueva wallet desde la linea de comandos puedes usar:
+```bash
+python wallet_cli.py create
+```
+
+
+ 
 
 ## Colaboración
 

--- a/wallet_cli.py
+++ b/wallet_cli.py
@@ -1,0 +1,11 @@
+from wallet import Wallet
+import argparse
+
+parser = argparse.ArgumentParser(description="Simple wallet CLI")
+parser.add_argument('command', choices=['create'], help='Command')
+args = parser.parse_args()
+
+if args.command == 'create':
+    wallet = Wallet()
+    print('Public Key:', wallet.get_public_key())
+    print('Address:', wallet.get_address())

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,44 @@
+from flask import Flask, jsonify, request, render_template, redirect, url_for
+from mscnet_blockchain import MSCNetBlockchain, Block
+from wallet import Wallet
+import time
+
+app = Flask(__name__)
+
+# Initialize blockchain and a temporary wallet to sign blocks
+blockchain = MSCNetBlockchain()
+wallet = Wallet()
+
+@app.route('/')
+def index():
+    chain = blockchain.chain
+    return render_template('index.html', chain=chain)
+
+@app.route('/chain')
+def get_chain():
+    chain_data = [block.__dict__ for block in blockchain.chain]
+    return jsonify(chain_data)
+
+@app.route('/add_block', methods=['POST'])
+def add_block():
+    data = request.form.get('data')
+    impact = float(request.form.get('impact', 0))
+    reputation = float(request.form.get('reputation', 1.0))
+    consistency = float(request.form.get('consistency', 0))
+
+    block_data = {
+        'agent_id': 'webapp',
+        'action': data,
+        'content': data,
+        'details': {},
+        'agent_public_key': wallet.get_public_key()
+    }
+    synth_proof = {'Ψ': reputation, 'Φ': impact, 'Ω': consistency}
+    last_block = blockchain.get_latest_block()
+    new_block = Block(last_block.index + 1, time.time(), block_data, synth_proof, last_block.hash)
+    new_block.sign_block(wallet.private_key)
+    blockchain.add_block(block_data, synth_proof, new_block.agent_signature)
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MSCNet Blockchain</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<h1>MSCNet Blockchain</h1>
+<h2>Current Chain</h2>
+<table>
+    <tr><th>Index</th><th>Timestamp</th><th>Hash</th><th>Previous Hash</th></tr>
+    {% for block in chain %}
+    <tr>
+        <td>{{ block.index }}</td>
+        <td>{{ block.timestamp }}</td>
+        <td>{{ block.hash[:10] }}...</td>
+        <td>{{ block.previous_hash[:10] }}...</td>
+    </tr>
+    {% endfor %}
+</table>
+<h2>Add Block</h2>
+<form action="/add_block" method="post">
+    <label>Data: <input type="text" name="data"></label><br>
+    <label>Impact (Φ): <input type="number" step="0.01" name="impact" value="0"></label><br>
+    <label>Reputation (Ψ): <input type="number" step="0.01" name="reputation" value="1.0"></label><br>
+    <label>Consistency (Ω): <input type="number" step="0.01" name="consistency" value="0"></label><br>
+    <button type="submit">Add Block</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small Flask web app that shows the blockchain and allows adding blocks
- add a CLI helper to create wallets
- document demo usage in README

## Testing
- `python -m py_compile webapp/app.py wallet_cli.py mscnet_blockchain.py wallet.py shynt_token.py`